### PR TITLE
게시글 및 댓글의 추천, 비추천, 추천취소 액션 추가

### DIFF
--- a/experience.controller.php
+++ b/experience.controller.php
@@ -35,10 +35,17 @@ class experienceController extends experience
 			'procBoardInsertComment',
 			'procBoardDeleteComment',
 			'procDocumentVoteUp',
+			'procDocumentVoteUpCancel',
+			'procDocumentVoteDown',
+			'procDocumentVoteDownCancel',
+			'procCommentVoteUp',
+			'procCommentVoteUpCancel',
+			'procCommentVoteDown',
+			'procCommentVoteDownCancel',
 			'procDocumentManageCheckedDocument',
 			'procSocialxeConfirmMail',
 			'procSocialxeInputAddInfo',
-			'procSocialxeCallback'
+			'procSocialxeCallback',
 		);
 
 		$config = $this->getConfig();
@@ -54,7 +61,11 @@ class experienceController extends experience
 		$_minus_point_act = array(
 			'procBoardDeleteDocument',
 			'procBoardDeleteComment',
-			'procDocumentManageCheckedDocument'
+			'procDocumentManageCheckedDocument',
+			'procDocumentVoteUpCancel',
+			'procDocumentVoteDownCancel',
+			'procCommentVoteUpCancel',
+			'procCommentVoteDownCancel',
 		);
 
 		//지정한 act 빼고, 오로지 포인트 적립만 경험치 지급


### PR DESCRIPTION
라이믹스에서 추가된 추천 취소 기능에 대한 액션은 필수적으로 추가되어야 합니다.
추천 및 추천 취소를 반복하여 악의적인 경험치 획득이 가능합니다.

이외에도 댓글 추천 액션과, 게시글/댓글의 비추천 액션도 추적할 수 있도록 했습니다.
비추천 액션이 포인트를 차감시킬 경우, 경험치도 차감시키는 것이 많은 운영진들이 의도하는 방향이라 판단되고
그렇지 않다고 하더라도 비추천이 항상 포인트를 차감시키는 액션이라고 볼 수 없고, 추천이 항상 포인트를 증가시키는 액션이라고도 볼 수 없으므로,
비추천도 지원하는 것이 일관성있는 작동이 될 것입니다.